### PR TITLE
change INTERNAL_HTTPS_PORT random port

### DIFF
--- a/lib/nproxy.js
+++ b/lib/nproxy.js
@@ -8,7 +8,7 @@ var log = require('./log');
 var utils = require('./utils');
 
 var DEFAULT_PORT = 8989;
-var INTERNAL_HTTPS_PORT = 8000;
+var INTERNAL_HTTPS_PORT = 0;
 var app;
 var httpServer;
 var httpsServer;
@@ -54,7 +54,11 @@ function nproxy(port, options){
   }, function(req, res){
     req.type = 'https';
     app(req, res);
-  }).listen(INTERNAL_HTTPS_PORT);
+  });
+  httpsServer.on('listening', function(){
+    INTERNAL_HTTPS_PORT = httpsServer.address().port;
+  });
+  httpsServer = httpsServer.listen(INTERNAL_HTTPS_PORT);
 
   proxyHttps();
 


### PR DESCRIPTION
First httpsServer listen to port 0, that means system will assign a random port. Then in the listening callback assign the exact port to INTERNAL_HTTPS_PORT.
