### PR TITLE
set the node module mime version to 1.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "connect": "2.9.1",
     "commander": "*",
-    "mime": "*",
+    "mime": "1.3.4",
     "step": "*"
   },
   "devDependencies":{

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "nproxy",
-  "author": "Goddy Zhao <goddy128@gmail.com> (http://goddyzhao.me)",
-  "version": "1.4.5",
+  "name": "proxy-static-files",
+  "author": "majiajun",
+  "version": "1.4.6",
   "description": "A cli proxy tool specialized in file replacing",
   "dependencies": {
     "connect": "2.9.1",
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/goddyZhao/nproxy.git"
+    "url": "https://github.com/leohihimax/nproxy.git"
   },
   "keywords": [
     "node.js",


### PR DESCRIPTION
Because node module mime in version 2 has a breaking change from 1.x
The API changes:
lookup() renamed to getType()
so now nproxy is not working, need pin the mime version to 1.3.4 in package.json